### PR TITLE
Remove all selected entries from asset blacklist

### DIFF
--- a/indra/llui/lltabcontainer.cpp
+++ b/indra/llui/lltabcontainer.cpp
@@ -1,11 +1,11 @@
-/** 
+/**
  * @file lltabcontainer.cpp
  * @brief LLTabContainer class
  *
  * $LicenseInfo:firstyear=2001&license=viewergpl$
- * 
+ *
  * Copyright (c) 2001-2009, Linden Research, Inc.
- * 
+ *
  * Second Life Viewer Source Code
  * The source code in this file ("Source Code") is provided by Linden Lab
  * to you under the terms of the GNU General Public License, version 2.0
@@ -13,17 +13,17 @@
  * ("Other License"), formally executed by you and Linden Lab.  Terms of
  * the GPL can be found in doc/GPL-license.txt in this distribution, or
  * online at http://secondlifegrid.net/programs/open_source/licensing/gplv2
- * 
+ *
  * There are special exceptions to the terms and conditions of the GPL as
  * it is applied to this Source Code. View the full text of the exception
  * in the file doc/FLOSS-exception.txt in this software distribution, or
  * online at
  * http://secondlifegrid.net/programs/open_source/licensing/flossexception
- * 
+ *
  * By copying, modifying or distributing this software, you acknowledge
  * that you have read and understood your obligations described above,
  * and agree to abide by those obligations.
- * 
+ *
  * ALL LINDEN LAB SOURCE CODE IS PROVIDED "AS IS." LINDEN LAB MAKES NO
  * WARRANTIES, EXPRESS, IMPLIED OR OTHERWISE, REGARDING ITS ACCURACY,
  * COMPLETENESS OR PERFORMANCE.
@@ -92,7 +92,7 @@ public:
 
 LLTabContainer::LLTabContainer(const std::string& name, const LLRect& rect, TabPosition pos,
 							   BOOL bordered, BOOL is_vertical )
-	: 
+	:
 	LLPanel(name, rect, bordered),
 	mCurrentTabIdx(-1),
 	mTabsHidden(FALSE),
@@ -114,7 +114,7 @@ LLTabContainer::LLTabContainer(const std::string& name, const LLRect& rect, TabP
 	mJumpNextArrowBtn(NULL),
 	mRightTabBtnOffset(0),
 	mTotalTabWidth(0)
-{ 
+{
 	//RN: HACK to support default min width for legacy vertical tab containers
 	if (mIsVertical)
 	{
@@ -237,7 +237,7 @@ void LLTabContainer::draw()
 		left = LLPANEL_BORDER_WIDTH + (has_scroll_arrows ? (TABCNTR_ARROW_BTN_SIZE * 2) : TABCNTR_TAB_H_PAD);
 		left -= getScrollPosPixels();
 	}
-	
+
 	// Hide all the buttons
 	if (getTabsHidden() || mIsVertical)
 	{
@@ -507,7 +507,7 @@ BOOL LLTabContainer::handleMouseUp( S32 x, S32 y, MASK mask )
 BOOL LLTabContainer::handleToolTip( S32 x, S32 y, std::string& msg, LLRect* sticky_rect )
 {
 	BOOL handled = LLPanel::handleToolTip( x, y, msg, sticky_rect );
-	if (!handled && getTabCount() > 0 && !getTabsHidden()) 
+	if (!handled && getTabCount() > 0 && !getTabsHidden())
 	{
 		LLTabTuple* firsttuple = getTab(0);
 
@@ -700,7 +700,7 @@ BOOL LLTabContainer::handleDragAndDrop(S32 x, S32 y, MASK mask,	BOOL drop,	EDrag
 				mDragAndDropDelayTimer.stop();
 			}
 		}
-		else 
+		else
 		{
 			// Start a timer so we don't open tabs as soon as we hover on them
 			mDragAndDropDelayTimer.start();
@@ -710,9 +710,9 @@ BOOL LLTabContainer::handleDragAndDrop(S32 x, S32 y, MASK mask,	BOOL drop,	EDrag
 	return LLView::handleDragAndDrop(x,	y, mask, drop, type, cargo_data,  accept, tooltip);
 }
 
-void LLTabContainer::addTabPanel(LLPanel* child, 
-								 const std::string& label, 
-								 BOOL select, 
+void LLTabContainer::addTabPanel(LLPanel* child,
+								 const std::string& label,
+								 BOOL select,
 								 S32 indent,
 								 BOOL placeholder,
 								 eInsertionPoint insertion_point)
@@ -735,16 +735,16 @@ void LLTabContainer::addTabPanel(LLPanel* child,
 	{
 		button_width = llclamp(font->getWidth(trimmed_label) + TAB_PADDING, mMinTabWidth, mMaxTabWidth);
 	}
-	
+
 	// Tab panel
 	S32 tab_panel_top;
 	S32 tab_panel_bottom;
-	if (!getTabsHidden()) 
+	if (!getTabsHidden())
 	{
 		if( getTabPosition() == LLTabContainer::TOP )
 		{
 			S32 tab_height = mIsVertical ? BTN_HEIGHT : TABCNTR_TAB_HEIGHT;
-			tab_panel_top = getRect().getHeight() - getTopBorderHeight() - (tab_height - TABCNTR_BUTTON_PANEL_OVERLAP);	
+			tab_panel_top = getRect().getHeight() - getTopBorderHeight() - (tab_height - TABCNTR_BUTTON_PANEL_OVERLAP);
 			tab_panel_bottom = LLPANEL_BORDER_WIDTH;
 		}
 		else
@@ -769,7 +769,7 @@ void LLTabContainer::addTabPanel(LLPanel* child,
 	}
 	else
 	{
-		tab_panel_rect = LLRect(LLPANEL_BORDER_WIDTH, 
+		tab_panel_rect = LLRect(LLPANEL_BORDER_WIDTH,
 								tab_panel_top,
 								getRect().getWidth()-LLPANEL_BORDER_WIDTH,
 								tab_panel_bottom );
@@ -811,12 +811,12 @@ void LLTabContainer::addTabPanel(LLPanel* child,
 
 	LLTextBox* textbox = NULL;
 	LLButton* btn = NULL;
-	
+
 	if (placeholder)
 	{
 		btn_rect.translate(0, -LLBUTTON_V_PAD-2);
 		textbox = new LLTextBox(trimmed_label, btn_rect, trimmed_label, font);
-		
+
 		btn = new LLButton(LLStringUtil::null);
 	}
 	else
@@ -826,8 +826,8 @@ void LLTabContainer::addTabPanel(LLPanel* child,
 			btn = new LLButton(std::string("vert tab button"),
 							   btn_rect,
 							   LLStringUtil::null,
-							   LLStringUtil::null, 
-							   LLStringUtil::null, 
+							   LLStringUtil::null,
+							   LLStringUtil::null,
 							   NULL,
 							   font,
 							   trimmed_label, trimmed_label);
@@ -843,18 +843,13 @@ void LLTabContainer::addTabPanel(LLPanel* child,
 		}
 		else
 		{
-			std::string tooltip = trimmed_label;
-			tooltip += "\nAlt-Left arrow for previous tab";
-			tooltip += "\nAlt-Right arrow for next tab";
-
 			btn = new LLButton(std::string(child->getName()) + " tab",
-							   btn_rect, 
+							   btn_rect,
 							   LLStringUtil::null, LLStringUtil::null, LLStringUtil::null,
 							   NULL, // set userdata below
 							   font,
 							   trimmed_label, trimmed_label );
 			btn->setVisible( FALSE );
-			btn->setToolTip( tooltip );
 			btn->setScaleImage(TRUE);
 			btn->setImages(tab_img, tab_selected_img);
 
@@ -877,8 +872,13 @@ void LLTabContainer::addTabPanel(LLPanel* child,
 				btn->setFollowsBottom();
 			}
 		}
+		std::string tooltip = trimmed_label;
+		// FIXME: Tooltip can not be translated when hardcoded.
+		tooltip += "\nAlt-Left arrow for previous tab";
+		tooltip += "\nAlt-Right arrow for next tab";
+		btn->setToolTip( tooltip );
 	}
-	
+
 	LLTabTuple* tuple = new LLTabTuple( this, child, btn, textbox );
 	insertTuple( tuple, insertion_point );
 
@@ -906,7 +906,7 @@ void LLTabContainer::addTabPanel(LLPanel* child,
 	sendChildToFront(mNextArrowBtn);
 	sendChildToFront(mJumpPrevArrowBtn);
 	sendChildToFront(mJumpNextArrowBtn);
-	
+
 	if( select )
 	{
 		selectLastTab();
@@ -958,7 +958,7 @@ void LLTabContainer::removeTabPanel(LLPanel* child)
 			}
 		}
 	}
-	
+
 	BOOL has_focus = gFocusMgr.childHasKeyboardFocus(this);
 
 	// If the tab being deleted is the selected one, select a different tab.
@@ -972,7 +972,7 @@ void LLTabContainer::removeTabPanel(LLPanel* child)
 
  			removeChild( tuple->mTabPanel );
 // 			delete tuple->mTabPanel;
-			
+
 			mTabList.erase( iter );
 			delete tuple;
 
@@ -1041,7 +1041,7 @@ void LLTabContainer::deleteAllTabs()
 	// Actually delete the tuples themselves
 	std::for_each(mTabList.begin(), mTabList.end(), DeletePointer());
 	mTabList.clear();
-	
+
 	// And there isn't a current tab any more
 	mCurrentTabIdx = -1;
 }
@@ -1173,7 +1173,7 @@ void LLTabContainer::selectPrevTab()
 	{
 		mTabList[idx]->mButton->setFocus(TRUE);
 	}
-}	
+}
 
 BOOL LLTabContainer::selectTabPanel(LLPanel* child)
 {
@@ -1205,7 +1205,7 @@ BOOL LLTabContainer::selectTab(S32 which)
 	{
 		return FALSE;
 	}
-	
+
 	LLSD cbdata;
 	if (selected_tuple->mTabPanel)
 		cbdata = selected_tuple->mTabPanel->getName();
@@ -1219,7 +1219,7 @@ BOOL LLTabContainer::selectTab(S32 which)
 			(*mCommitSignal)(this, cbdata);
 		}
 	}
-	
+
 	return res;
 }
 
@@ -1247,7 +1247,7 @@ BOOL LLTabContainer::setTab(S32 which)
 			tuple->mButton->setToggleState( is_selected );
 			// RN: this limits tab-stops to active button only, which would require arrow keys to switch tabs
 			tuple->mButton->setTabStop( is_selected );
-			
+
 			if (is_selected)
 			{
 				// Make sure selected tab is within scroll region
@@ -1391,7 +1391,7 @@ void LLTabContainer::reshapeTuple(LLTabTuple* tuple)
 	{
 		const LLFontGL* fontp = LLResMgr::getInstance()->getRes( LLFONT_SANSSERIF_SMALL );
 		S32 image_overlay_width = 0;
-		image_overlay_width = tuple->mButton->getImageOverlay().notNull() ? 
+		image_overlay_width = tuple->mButton->getImageOverlay().notNull() ?
 				tuple->mButton->getImageOverlay()->getImage()->getWidth(0) : 0;
 		// remove current width from total tab strip width
 		mTotalTabWidth -= tuple->mButton->getRect().getWidth();
@@ -1401,7 +1401,7 @@ void LLTabContainer::reshapeTuple(LLTabTuple* tuple)
 		tuple->mPadding = image_overlay_width;
 
 		tuple->mButton->setRightHPad(6);
-		tuple->mButton->reshape(llclamp(fontp->getWidth(tuple->mButton->getLabelSelected()) + TAB_PADDING + tuple->mPadding, mMinTabWidth, mMaxTabWidth), 
+		tuple->mButton->reshape(llclamp(fontp->getWidth(tuple->mButton->getLabelSelected()) + TAB_PADDING + tuple->mPadding, mMinTabWidth, mMaxTabWidth),
 									tuple->mButton->getRect().getHeight());
 		// add back in button width to total tab strip width
 		mTotalTabWidth += tuple->mButton->getRect().getWidth();
@@ -1412,7 +1412,7 @@ void LLTabContainer::reshapeTuple(LLTabTuple* tuple)
 }
 
 void LLTabContainer::setTitle(const std::string& title)
-{	
+{
 	if (mTitleBox)
 	{
 		mTitleBox->setText( title );
@@ -1556,7 +1556,7 @@ LLView* LLTabContainer::fromXML(LLXMLNodePtr node, LLView *parent, LLUICtrlFacto
 	node->getAttributeBOOL("border", border);
 
 	LLTabContainer*	tab_container = new LLTabContainer(name, LLRect::null, tab_position, border, is_vertical);
-	
+
 	S32 tab_min_width = tab_container->mMinTabWidth;
 	if (node->hasAttribute("tab_width"))
 	{
@@ -1573,9 +1573,9 @@ LLView* LLTabContainer::fromXML(LLXMLNodePtr node, LLView *parent, LLUICtrlFacto
 		node->getAttributeS32("tab_max_width", tab_max_width);
 	}
 
-	tab_container->setMinTabWidth(tab_min_width); 
-	tab_container->setMaxTabWidth(tab_max_width); 
-	
+	tab_container->setMinTabWidth(tab_min_width);
+	tab_container->setMaxTabWidth(tab_max_width);
+
 	BOOL hidden(tab_container->getTabsHidden());
 	node->getAttributeBOOL("hide_tabs", hidden);
 	tab_container->setTabsHidden(hidden);
@@ -1614,7 +1614,7 @@ LLView* LLTabContainer::fromXML(LLXMLNodePtr node, LLView *parent, LLUICtrlFacto
 	tab_container->postBuild();
 
 	tab_container->initButtons(); // now that we have the correct rect
-	
+
 	return tab_container;
 }
 
@@ -1627,7 +1627,7 @@ void LLTabContainer::initButtons()
 	{
 		return; // Don't have a rect yet or already got called
 	}
-	
+
 	std::string out_id;
 	std::string in_id;
 
@@ -1650,7 +1650,7 @@ void LLTabContainer::initButtons()
 		mPrevArrowBtn->setFollowsTop();
 		mPrevArrowBtn->setFollowsLeft();
 		mPrevArrowBtn->setHeldDownCallback(boost::bind(&LLTabContainer::onPrevBtnHeld, this, _2));
-		
+
 		out_id = "UIImgBtnScrollDownOutUUID";
 		in_id = "UIImgBtnScrollDownInUUID";
 		mNextArrowBtn = new LLButton(std::string("Down Arrow"), down_arrow_btn_rect,
@@ -1661,7 +1661,7 @@ void LLTabContainer::initButtons()
 	}
 	else // Horizontal
 	{
-		S32 arrow_fudge = 1;		//  match new art better 
+		S32 arrow_fudge = 1;		//  match new art better
 
 		// tabs on bottom reserve room for resize handle (just in case)
 		if (getTabPosition() == BOTTOM)
@@ -1705,7 +1705,7 @@ void LLTabContainer::initButtons()
 									 boost::bind(&LLTabContainer::onPrevBtn, this, _2), LLFontGL::getFontSansSerif() );
 		mPrevArrowBtn->setHeldDownCallback(boost::bind(&LLTabContainer::onPrevBtnHeld, this, _2));
 		mPrevArrowBtn->setFollowsLeft();
-	
+
 		out_id = "UIImgBtnJumpRightOutUUID";
 		in_id = "UIImgBtnJumpRightInUUID";
 		mJumpNextArrowBtn = new LLButton(std::string("Jump Right Arrow"), jump_right_arrow_btn_rect,
@@ -1740,7 +1740,7 @@ void LLTabContainer::initButtons()
 	mPrevArrowBtn->setSaveToXML(false);
 	mPrevArrowBtn->setTabStop(FALSE);
 	addChild(mPrevArrowBtn);
-	
+
 	mNextArrowBtn->setSaveToXML(false);
 	mNextArrowBtn->setTabStop(FALSE);
 	addChild(mNextArrowBtn);
@@ -1758,7 +1758,7 @@ void LLTabContainer::initButtons()
 		mJumpNextArrowBtn->setTabStop(FALSE);
 		addChild(mJumpNextArrowBtn);
 	}
-	
+
 	// set default tab group to be panel contents
 	setDefaultTabGroup(1);
 }

--- a/indra/newview/llfloaterblacklist.cpp
+++ b/indra/newview/llfloaterblacklist.cpp
@@ -208,11 +208,12 @@ void LLFloaterBlacklist::onClickRemove(void* user_data)
 	if(list->getFirstSelected())
 	{
 		uuid_vec_t selectedIDs = list->getSelectedIDs();
-		for(typename uuid_vec_t::iterator iterator = selectedIDs.begin();
-		        iterator != selectedIDs.end();
-		        ++iterator) {
+		typename uuid_vec_t::const_iterator iterator;
+		for(iterator  = selectedIDs.begin();
+		    iterator != selectedIDs.end();
+		    ++iterator)
+		{
 			LLUUID selectedID = *iterator;
-			if(selectedID.isNull()) continue;
 			blacklist_entries.erase(selectedID);
 		}
 		list->deleteSelectedItems();

--- a/indra/newview/llfloaterblacklist.cpp
+++ b/indra/newview/llfloaterblacklist.cpp
@@ -85,7 +85,7 @@ BOOL LLFloaterBlacklist::postBuild()
 }
 void LLFloaterBlacklist::refresh()
 {
-	
+
 	LLScrollListCtrl* list = getChild<LLScrollListCtrl>("file_list");
 	list->clearRows();
 	for(std::map<LLUUID,LLSD>::iterator iter = blacklist_entries.begin(); iter != blacklist_entries.end(); ++iter)
@@ -207,13 +207,16 @@ void LLFloaterBlacklist::onClickRemove(void* user_data)
 	LLScrollListCtrl* list = floaterp->getChild<LLScrollListCtrl>("file_list");
 	if(list->getFirstSelected())
 	{
-		LLScrollListItem* item = list->getFirstSelected();
-		LLUUID selected_id = item->getColumn(0)->getValue().asUUID();
-		if(selected_id.isNull()) return;
-		list->deleteSingleItem(list->getFirstSelectedIndex());
-		blacklist_entries.erase(selected_id);
+		uuid_vec_t selectedIDs = list->getSelectedIDs();
+		for(typename uuid_vec_t::iterator iterator = selectedIDs.begin();
+		        iterator != selectedIDs.end();
+		        ++iterator) {
+			LLUUID selectedID = *iterator;
+			if(selectedID.isNull()) continue;
+			blacklist_entries.erase(selectedID);
+		}
+		list->deleteSelectedItems();
 		updateBlacklists();
-		
 	}
 }
 // static
@@ -252,12 +255,12 @@ void LLFloaterBlacklist::updateBlacklists()
 			{
 				gAssetStorage->mBlackListedAsset.push_back(LLUUID(iter->first));
 			}
-			
+
 			if(blacklist_entries[iter->first]["entry_type"].asString() == "6")
 			{
 				blacklist_objects.push_back(LLUUID(iter->first));
 			}
-			
+
 		}
 		saveToDisk();
 		LLFloaterBlacklist* instance = LLFloaterBlacklist::getInstance();
@@ -300,7 +303,7 @@ void LLFloaterBlacklist::onClickSave_continued(AIFilePicker* filepicker)
 		{
 			data[iter->first.asString()] = iter->second;
 		}
-		LLSDSerialize::toPrettyXML(data, export_file);	
+		LLSDSerialize::toPrettyXML(data, export_file);
 		export_file.close();
 	}
 }

--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -1,11 +1,11 @@
-/** 
+/**
  * @file llpreviewscript.cpp
  * @brief LLPreviewScript class implementation
  *
  * $LicenseInfo:firstyear=2002&license=viewergpl$
- * 
+ *
  * Copyright (c) 2002-2009, Linden Research, Inc.
- * 
+ *
  * Second Life Viewer Source Code
  * The source code in this file ("Source Code") is provided by Linden Lab
  * to you under the terms of the GNU General Public License, version 2.0
@@ -13,17 +13,17 @@
  * ("Other License"), formally executed by you and Linden Lab.  Terms of
  * the GPL can be found in doc/GPL-license.txt in this distribution, or
  * online at http://secondlifegrid.net/programs/open_source/licensing/gplv2
- * 
+ *
  * There are special exceptions to the terms and conditions of the GPL as
  * it is applied to this Source Code. View the full text of the exception
  * in the file doc/FLOSS-exception.txt in this software distribution, or
  * online at
  * http://secondlifegrid.net/programs/open_source/licensing/flossexception
- * 
+ *
  * By copying, modifying or distributing this software, you acknowledge
  * that you have read and understood your obligations described above,
  * and agree to abide by those obligations.
- * 
+ *
  * ALL LINDEN LAB SOURCE CODE IS PROVIDED "AS IS." LINDEN LAB MAKES NO
  * WARRANTIES, EXPRESS, IMPLIED OR OTHERWISE, REGARDING ITS ACCURACY,
  * COMPLETENESS OR PERFORMANCE.
@@ -116,13 +116,13 @@ const S32 LINE_COLUMN_HEIGHT = 14;
 
 const S32 SCRIPT_EDITOR_MIN_HEIGHT = 2 * SCROLLBAR_SIZE + 2 * LLPANEL_BORDER_WIDTH + 128;
 
-const S32 SCRIPT_MIN_WIDTH = 
-	2 * SCRIPT_BORDER + 
-	2 * SCRIPT_BUTTON_WIDTH + 
+const S32 SCRIPT_MIN_WIDTH =
+	2 * SCRIPT_BORDER +
+	2 * SCRIPT_BUTTON_WIDTH +
 	SCRIPT_PAD + RESIZE_HANDLE_WIDTH +
 	SCRIPT_PAD;
 
-const S32 SCRIPT_MIN_HEIGHT = 
+const S32 SCRIPT_MIN_HEIGHT =
 	2 * SCRIPT_BORDER +
 	3*(SCRIPT_BUTTON_HEIGHT + SCRIPT_PAD) +
 	LINE_COLUMN_HEIGHT +
@@ -209,7 +209,7 @@ void LLScriptEdCore::parseFunctions(const std::string& filename)
 		{
 			LLSDSerialize::fromXMLDocument(function_list, importer);
 			importer.close();
-			
+
 			for (LLSD::map_const_iterator it = function_list.beginMap(); it != function_list.endMap(); ++it)
 			{
 				LSLFunctionProps fn;
@@ -267,7 +267,7 @@ BOOL LLScriptEdCore::postBuild()
 	mErrorList = getChild<LLScrollListCtrl>("lsl errors");
 
 	mFunctions = getChild<LLComboBox>( "Insert...");
-	
+
 	childSetCommitCallback("Insert...", &LLScriptEdCore::onBtnInsertFunction, this);
 
 	mEditor = getChild<LLViewerTextEditor>("Script Editor");
@@ -290,25 +290,25 @@ BOOL LLScriptEdCore::postBuild()
 		{
 			std::string name = i->mName;
 			funcs.push_back(name);
-			
+
 			std::string desc_name = "LSLTipText_";
 			desc_name += name;
 			std::string desc = LLTrans::getString(desc_name);
-			
+
 			F32 sleep_time = i->mSleepTime;
 			if( sleep_time )
 			{
 				desc += "\n";
-				
+
 				LLStringUtil::format_map_t args;
 				args["[SLEEP_TIME]"] = llformat("%.1f", sleep_time );
 				desc += LLTrans::getString("LSLTipSleepTime", args);
 			}
-			
+
 			// A \n linefeed is not part of xml. Let's add one to keep all
 			// the tips one-per-line in strings.xml
 			LLStringUtil::replaceString( desc, "\\n", "\n" );
-			
+
 			tooltips.push_back(desc);
 		}
 	}
@@ -366,7 +366,7 @@ void LLScriptEdCore::initMenu()
 	menuItem = getChild<LLMenuItemCallGL>("Save");
 	menuItem->setMenuCallback(onBtnSave, this);
 	menuItem->setEnabledCallback(hasChanged);
-	
+
 	menuItem = getChild<LLMenuItemCallGL>("Revert All Changes");
 	menuItem->setMenuCallback(onBtnUndoChanges, this);
 	menuItem->setEnabledCallback(hasChanged);
@@ -594,7 +594,7 @@ void LLScriptEdCore::setHelpPage(const std::string& help_string)
 {
 	LLFloater* help_floater = mLiveHelpHandle.get();
 	if (!help_floater) return;
-	
+
 	LLMediaCtrl* web_browser = help_floater->getChild<LLMediaCtrl>("lsl_guide_html");
 	if (!web_browser) return;
 
@@ -699,7 +699,7 @@ bool LLScriptEdCore::handleSaveChangesDialog(const LLSD& notification, const LLS
 	return false;
 }
 
-// static 
+// static
 bool LLScriptEdCore::onHelpWebDialog(const LLSD& notification, const LLSD& response)
 {
 	S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
@@ -715,7 +715,7 @@ bool LLScriptEdCore::onHelpWebDialog(const LLSD& notification, const LLSD& respo
 	return false;
 }
 
-// static 
+// static
 void LLScriptEdCore::onBtnHelp(void* userdata)
 {
 	LLSD payload;
@@ -723,7 +723,7 @@ void LLScriptEdCore::onBtnHelp(void* userdata)
 	LLNotificationsUtil::add("WebLaunchLSLGuide", LLSD(), payload, onHelpWebDialog);
 }
 
-// static 
+// static
 void LLScriptEdCore::onBtnDynamicHelp(void* userdata)
 {
 	LLScriptEdCore* corep = (LLScriptEdCore*)userdata;
@@ -752,8 +752,8 @@ void LLScriptEdCore::onBtnDynamicHelp(void* userdata)
 	LLComboBox* help_combo = live_help_floater->getChild<LLComboBox>("history_combo");
 	LLKeywordToken *token;
 	LLKeywords::keyword_iterator_t token_it;
-	for (token_it = corep->mEditor->keywordsBegin(); 
-		token_it != corep->mEditor->keywordsEnd(); 
+	for (token_it = corep->mEditor->keywordsBegin();
+		token_it != corep->mEditor->keywordsEnd();
 		++token_it)
 	{
 		token = token_it->second;
@@ -768,7 +768,7 @@ void LLScriptEdCore::onBtnDynamicHelp(void* userdata)
 	corep->updateDynamicHelp(TRUE);
 }
 
-//static 
+//static
 void LLScriptEdCore::onClickBack(void* userdata)
 {
 	LLScriptEdCore* corep = (LLScriptEdCore*)userdata;
@@ -783,7 +783,7 @@ void LLScriptEdCore::onClickBack(void* userdata)
 	}
 }
 
-//static 
+//static
 void LLScriptEdCore::onClickForward(void* userdata)
 {
 	LLScriptEdCore* corep = (LLScriptEdCore*)userdata;
@@ -809,7 +809,7 @@ void LLScriptEdCore::onCheckLock(LLUICtrl* ctrl, void* userdata)
 	corep->mLastHelpToken = NULL;
 }
 
-// static 
+// static
 void LLScriptEdCore::onBtnInsertSample(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*) userdata;
@@ -820,7 +820,7 @@ void LLScriptEdCore::onBtnInsertSample(void* userdata)
 	self->mEditor->insertText(self->mSampleText);
 }
 
-// static 
+// static
 void LLScriptEdCore::onHelpComboCommit(LLUICtrl* ctrl, void* userdata)
 {
 	LLScriptEdCore* corep = (LLScriptEdCore*)userdata;
@@ -839,7 +839,7 @@ void LLScriptEdCore::onHelpComboCommit(LLUICtrl* ctrl, void* userdata)
 	}
 }
 
-// static 
+// static
 void LLScriptEdCore::onBtnInsertFunction(LLUICtrl *ui, void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*) userdata;
@@ -943,7 +943,7 @@ void LLScriptEdCore::onSearchMenu(void* userdata)
 	}
 }
 
-// static 
+// static
 void LLScriptEdCore::onUndoMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -951,7 +951,7 @@ void LLScriptEdCore::onUndoMenu(void* userdata)
 	self->mEditor->undo();
 }
 
-// static 
+// static
 void LLScriptEdCore::onRedoMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -959,7 +959,7 @@ void LLScriptEdCore::onRedoMenu(void* userdata)
 	self->mEditor->redo();
 }
 
-// static 
+// static
 void LLScriptEdCore::onCutMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -967,7 +967,7 @@ void LLScriptEdCore::onCutMenu(void* userdata)
 	self->mEditor->cut();
 }
 
-// static 
+// static
 void LLScriptEdCore::onCopyMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -975,7 +975,7 @@ void LLScriptEdCore::onCopyMenu(void* userdata)
 	self->mEditor->copy();
 }
 
-// static 
+// static
 void LLScriptEdCore::onPasteMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -983,7 +983,7 @@ void LLScriptEdCore::onPasteMenu(void* userdata)
 	self->mEditor->paste();
 }
 
-// static 
+// static
 void LLScriptEdCore::onSelectAllMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -991,7 +991,7 @@ void LLScriptEdCore::onSelectAllMenu(void* userdata)
 	self->mEditor->selectAll();
 }
 
-// static 
+// static
 void LLScriptEdCore::onDeselectMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -999,7 +999,7 @@ void LLScriptEdCore::onDeselectMenu(void* userdata)
 	self->mEditor->deselect();
 }
 
-// static 
+// static
 BOOL LLScriptEdCore::enableUndoMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -1007,7 +1007,7 @@ BOOL LLScriptEdCore::enableUndoMenu(void* userdata)
 	return self->mEditor->canUndo();
 }
 
-// static 
+// static
 BOOL LLScriptEdCore::enableRedoMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -1015,7 +1015,7 @@ BOOL LLScriptEdCore::enableRedoMenu(void* userdata)
 	return self->mEditor->canRedo();
 }
 
-// static 
+// static
 BOOL LLScriptEdCore::enableCutMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -1023,7 +1023,7 @@ BOOL LLScriptEdCore::enableCutMenu(void* userdata)
 	return self->mEditor->canCut();
 }
 
-// static 
+// static
 BOOL LLScriptEdCore::enableCopyMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -1031,7 +1031,7 @@ BOOL LLScriptEdCore::enableCopyMenu(void* userdata)
 	return self->mEditor->canCopy();
 }
 
-// static 
+// static
 BOOL LLScriptEdCore::enablePasteMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -1039,7 +1039,7 @@ BOOL LLScriptEdCore::enablePasteMenu(void* userdata)
 	return self->mEditor->canPaste();
 }
 
-// static 
+// static
 BOOL LLScriptEdCore::enableSelectAllMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -1047,7 +1047,7 @@ BOOL LLScriptEdCore::enableSelectAllMenu(void* userdata)
 	return self->mEditor->canSelectAll();
 }
 
-// static 
+// static
 BOOL LLScriptEdCore::enableDeselectMenu(void* userdata)
 {
 	LLScriptEdCore* self = (LLScriptEdCore*)userdata;
@@ -1074,7 +1074,6 @@ void LLScriptEdCore::onErrorList(LLUICtrl*, void* user_data)
 		//LL_INFOS() << "LLScriptEdCore::onErrorList() - " << row << ", "
 		//<< column << LL_ENDL;
 		self->mEditor->setCursor(row, column);
-		self->mEditor->setFocus(TRUE);
 	}
 }
 
@@ -1246,7 +1245,7 @@ struct LLScriptSaveInfo
 //static
 void* LLPreviewLSL::createScriptEdPanel(void* userdata)
 {
-	
+
 	LLPreviewLSL *self = (LLPreviewLSL*)userdata;
 
 	self->mScriptEd =  new LLScriptEdCore(
@@ -1274,7 +1273,7 @@ LLPreviewLSL::LLPreviewLSL(const std::string& name, const LLRect& rect, const st
 // virtual
 BOOL LLPreviewLSL::postBuild()
 {
-	const LLInventoryItem* item = getItem();	
+	const LLInventoryItem* item = getItem();
 
 	llassert(item);
 	if (item)
@@ -1332,7 +1331,7 @@ void LLPreviewLSL::loadAsset()
 	}
 	if(item)
 	{
-		BOOL is_copyable = gAgent.allowOperation(PERM_COPY, 
+		BOOL is_copyable = gAgent.allowOperation(PERM_COPY,
 								item->getPermissions(), GP_OBJECT_MANIPULATE);
 		BOOL is_modifiable = gAgent.allowOperation(PERM_MODIFY,
 								item->getPermissions(), GP_OBJECT_MANIPULATE);
@@ -1390,7 +1389,7 @@ void LLPreviewLSL::closeIfNeeded()
 void LLPreviewLSL::onSearchReplace(void* userdata)
 {
 	LLPreviewLSL* self = (LLPreviewLSL*)userdata;
-	LLScriptEdCore* sec = self->mScriptEd; 
+	LLScriptEdCore* sec = self->mScriptEd;
 	if (sec && sec->mEditor)
 	{
 		LLFloaterSearchReplace::show(sec->mEditor);
@@ -1524,7 +1523,7 @@ void LLPreviewLSL::uploadAssetLegacy(const std::string& filename,
 		{
 			char buffer[MAX_STRING];		/*Flawfinder: ignore*/
 			std::string line;
-			while(!feof(fp)) 
+			while(!feof(fp))
 			{
 				if (fgets(buffer, MAX_STRING, fp) == NULL)
 				{
@@ -1689,7 +1688,7 @@ void LLPreviewLSL::onLoadComplete( LLVFS *vfs, const LLUUID& asset_uuid, LLAsset
 			   && gAgent.allowOperation(PERM_MODIFY, item->getPermissions(),
 				   					GP_OBJECT_MANIPULATE))
 			{
-				is_modifiable = TRUE;		
+				is_modifiable = TRUE;
 			}
 			preview->mScriptEd->setEnableEditing(is_modifiable);
 			preview->mAssetStatus = PREVIEW_ASSET_LOADED;
@@ -1725,10 +1724,10 @@ void LLPreviewLSL::onLoadComplete( LLVFS *vfs, const LLUUID& asset_uuid, LLAsset
 /// ---------------------------------------------------------------------------
 
 
-//static 
+//static
 void* LLLiveLSLEditor::createScriptEdPanel(void* userdata)
 {
-	
+
 	LLLiveLSLEditor *self = (LLLiveLSLEditor*)userdata;
 
 	self->mScriptEd =  new LLScriptEdCore(
@@ -1816,7 +1815,7 @@ void LLLiveLSLEditor::loadAsset()
 		if(object)
 		{
 			LLViewerInventoryItem* item = dynamic_cast<LLViewerInventoryItem*>(object->getInventoryObject(mItemUUID));
-			if(item 
+			if(item
 				&& (gAgent.allowOperation(PERM_COPY, item->getPermissions(), GP_OBJECT_MANIPULATE)
 				   || gAgent.isGodlike()))
 			{
@@ -1866,7 +1865,7 @@ void LLLiveLSLEditor::loadAsset()
 				mAssetStatus = PREVIEW_ASSET_LOADED;
 			}
 
-			mIsModifiable = item && gAgent.allowOperation(PERM_MODIFY, 
+			mIsModifiable = item && gAgent.allowOperation(PERM_MODIFY,
 										item->getPermissions(),
 				   						GP_OBJECT_MANIPULATE);
 			refreshFromItem(item);
@@ -2032,7 +2031,7 @@ void LLLiveLSLEditor::onReset(void *userdata)
 	}
 	else
 	{
-		LLNotificationsUtil::add("CouldNotStartStopScript"); 
+		LLNotificationsUtil::add("CouldNotStartStopScript");
 	}
 }
 
@@ -2097,7 +2096,7 @@ void LLLiveLSLEditor::onSearchReplace(void* userdata)
 {
 	LLLiveLSLEditor* self = (LLLiveLSLEditor*)userdata;
 
-	LLScriptEdCore* sec = self->mScriptEd; 
+	LLScriptEdCore* sec = self->mScriptEd;
 	if (sec && sec->mEditor)
 	{
 		LLFloaterSearchReplace::show(sec->mEditor);
@@ -2188,7 +2187,7 @@ void LLLiveLSLEditor::saveIfNeeded(bool sync /*= true*/)
 	{
 		mScriptEd->sync();
 	}
-	
+
 	// save it out to asset server
 	std::string url = object->getRegion()->getCapability("UpdateScriptTask");
 	getWindow()->incBusyCount();
@@ -2262,9 +2261,9 @@ void LLLiveLSLEditor::uploadAssetLegacy(const std::string& filename,
 		{
 			char buffer[MAX_STRING];		/*Flawfinder: ignore*/
 			std::string line;
-			while(!feof(fp)) 
+			while(!feof(fp))
 			{
-				
+
 				if (fgets(buffer, MAX_STRING, fp) == NULL)
 				{
 					buffer[0] = '\0';
@@ -2277,7 +2276,7 @@ void LLLiveLSLEditor::uploadAssetLegacy(const std::string& filename,
 				{
 					line.assign(buffer);
 					LLStringUtil::stripNonprintable(line);
-				
+
 					LLSD row;
 					row["columns"][0]["value"] = line;
 					row["columns"][0]["font"] = "OCRA";

--- a/indra/newview/skins/default/xui/en-us/floater_script_ed_panel.xml
+++ b/indra/newview/skins/default/xui/en-us/floater_script_ed_panel.xml
@@ -17,7 +17,7 @@
 	<scroll_list background_visible="true" bottom="-457" column_padding="5" draw_border="true"
 	     draw_heading="false" draw_stripes="true" enabled="true"
 	     follows="left|right|bottom" height="60" left="4" mouse_opaque="true"
-	     multi_select="false" name="lsl errors" width="492" />
+	     multi_select="true" name="lsl errors" width="492" />
 	<combo_box allow_text_entry="false" bottom="-499" enabled="true" follows="left|bottom"
 	     height="20" label="Insert..." left="12" max_chars="20" mouse_opaque="true"
 	     name="Insert..." width="128" />


### PR DESCRIPTION
Previously, the "Remove" button in the asset blacklist floater removed
the last clicked-on entry only - even when selecting multiple rows (by
holding CTRL and clicking on entries).
This behaviour is unintuitive and tedious when trying to selectively
remove multiple entries.

The feature was requested in the group chat. Tested both removing a
single entry and multiple entries with two different avatars on Linux.