### PR TITLE
Fixed female torso muscles slider not working above 50

### DIFF
--- a/indra/newview/character/avatar_lad.xml
+++ b/indra/newview/character/avatar_lad.xml
@@ -3655,6 +3655,7 @@
        group="1"
        name="Muscular_Torso"
        label="Torso Muscles"
+       sex="male"
 	   show_simple="true"
        wearable="shape"
        edit_group="shape_torso"
@@ -3691,6 +3692,49 @@
 				pos="0.005 0 0"/>
 		 </param_morph>
       </param>
+
+     <param
+     id="107"
+     group="1"
+     name="Muscular_Torso"
+     label="Torso Muscles"
+     sex="female"
+	   show_simple="true"
+     wearable="shape"
+     edit_group="shape_torso"
+     label_min="Regular"
+     label_max="Muscular"
+     value_min="0"
+     value_max="1.4"
+     camera_elevation=".3"
+     camera_distance="1.2">
+       <param_morph>
+         <volume_morph
+           name="L_CLAVICLE"
+           scale="0.02 0.0 0.005"
+           pos="0.0 0 0.005"/>
+         <volume_morph
+           name="L_UPPER_ARM"
+           scale="0.015 0.0 0.005"
+           pos="0.015 0 0"/>
+         <volume_morph
+           name="L_LOWER_ARM"
+           scale="0.005 0.0 0.005"
+           pos="0.005 0 0"/>
+         <volume_morph
+           name="R_CLAVICLE"
+           scale="0.02 0.0 0.005"
+           pos="0.0 0 0.005"/>
+         <volume_morph
+           name="R_UPPER_ARM"
+           scale="0.015 0.0 0.005"
+           pos="0.015 0 0"/>
+         <volume_morph
+           name="R_LOWER_ARM"
+           scale="0.005 0.0 0.005"
+           pos="0.005 0 0"/>
+       </param_morph>
+     </param>
 
       <param
        id="648"
@@ -10263,7 +10307,7 @@
              min2=".5" />
 
             <driven
-             id="106"
+             id="107"
              min1=".5"
              max1="1"
              max2="1"


### PR DESCRIPTION
Currently ranges 51-100 for female Torso Muscles don't have any visual change for female shapes, forcing you to change the shape to male, adjust the slider higher than 50, then change back to female. With this fix it is not necessary and the slider just works correctly.

Tested: You don't need to have the fix to see others using the new ranges, you only need the fix to use the new range yourself. New range uses the same deformations as the old gender swap trick.