### PR TITLE
autobuild.xml: change 'Unix Makefiles' to Unix Makefiles

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2918,7 +2918,7 @@
                 <key>options</key>
                 <array>
                   <string>-G</string>
-                  <string>'Unix Makefiles'</string>
+                  <string>Unix Makefiles</string>
                 </array>
               </map>
               <key>default</key>
@@ -2942,7 +2942,7 @@
                 <key>options</key>
                 <array>
                   <string>-G</string>
-                  <string>'Unix Makefiles'</string>
+                  <string>Unix Makefiles</string>
                 </array>
               </map>
               <key>name</key>
@@ -2974,7 +2974,7 @@
                 <key>options</key>
                 <array>
                   <string>-G</string>
-                  <string>'Unix Makefiles'</string>
+                  <string>Unix Makefiles</string>
                   <string>-DWORD_SIZE:STRING=64</string>
                 </array>
               </map>
@@ -2999,7 +2999,7 @@
                 <key>options</key>
                 <array>
                   <string>-G</string>
-                  <string>'Unix Makefiles'</string>
+                  <string>Unix Makefiles</string>
                   <string>-DWORD_SIZE:STRING=64</string>
                 </array>
               </map>


### PR DESCRIPTION
So, this allows autobuild to work on my setup. Without this change, I get the error:

    CMake Error: Could not create named generator 'Unix Makefiles'

But feel free to close this if I'm misunderstanding the build setup or something, or
if this breaks things for other people.

I'm running autobuild like this:

    ~/ve/bin/autobuild build -p linux -A 64 --verbose --debug

And I'm using autobuild version 1.1.7, cmake 3.9.3, on Debian Linux.