### PR TITLE
Handle instances of skinned meshes with transforms

### DIFF
--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -1078,6 +1078,8 @@ bool LLDAELoader::OpenFile(const std::string& filename)
 	mTransform = rotation;
 
 	mTransform.condition();	
+
+	mBindTransform.setIdentity();
 	
 	U32 submodel_limit = count > 0 ? mGeneratedModelLimit/count : 0;
 	for (daeInt idx = 0; idx < count; ++idx)
@@ -1134,33 +1136,7 @@ bool LLDAELoader::OpenFile(const std::string& filename)
 	}
 
 	count = db->getElementCount(NULL, COLLADA_TYPE_SKIN);
-	for (daeInt idx = 0; idx < count; ++idx)
-	{	//add skinned meshes as instances
-		domSkin* skin = NULL;
-		db->getElement((daeElement**) &skin, idx, NULL, COLLADA_TYPE_SKIN);
-
-		if (skin)
-		{
-			domGeometry* geom = daeSafeCast<domGeometry>(skin->getSource().getElement());
-
-			if (geom)
-			{
-				domMesh* mesh = geom->getMesh();
-				if (mesh)
-				{
-					std::vector< LLPointer< LLModel > >::iterator i = mModelsMap[mesh].begin();
-					while (i != mModelsMap[mesh].end())
-					{
-						LLPointer<LLModel> mdl = *i;
-						LLDAELoader::processDomModel(mdl, &dae, root, mesh, skin);
-						i++;
-					}
-				}
-			}
-		}
-	}
-
-	LL_INFOS()<< "Collada skins processed: " << count <<LL_ENDL;
+	LL_INFOS()<< "Collada skins to be processed: " << count <<LL_ENDL;
 
 	daeElement* scene = root->getDescendant("visual_scene");
 	
@@ -1175,7 +1151,7 @@ bool LLDAELoader::OpenFile(const std::string& filename)
 
 	bool badElement = false;
 	
-	processElement( scene, badElement, &dae );
+	processElement( scene, badElement, &dae, root);
 	
 	if ( badElement )
 	{
@@ -1263,6 +1239,8 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
 
 			LLMatrix4 trans = normalized_transformation;
 			trans *= skin_info.mBindShapeMatrix;
+			trans *= mBindTransform;
+
 			skin_info.mBindShapeMatrix = trans;							
 		}
 
@@ -2018,9 +1996,9 @@ daeElement* LLDAELoader::getChildFromElement( daeElement* pElement, std::string 
 	return NULL;
 }
 
-void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* dae )
+void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* dae, daeElement* domRoot)
 {
-	LLMatrix4 saved_transform;
+	LLMatrix4 saved_transform, saved_bind_transform;
 	bool pushed_mat = false;
 
 	domNode* node = daeSafeCast<domNode>(element);
@@ -2028,6 +2006,7 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 	{
 		pushed_mat = true;
 		saved_transform = mTransform;
+		saved_bind_transform = mBindTransform;
 	}
 
 	domTranslate* translate = daeSafeCast<domTranslate>(element);
@@ -2035,12 +2014,17 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 	{
 		domFloat3 dom_value = translate->getValue();
 
-		LLMatrix4 translation;
+		LLMatrix4 translation, translation2;
 		translation.setTranslation(LLVector3(dom_value[0], dom_value[1], dom_value[2]));
+		translation2 = translation;
 
 		translation *= mTransform;
 		mTransform = translation;
 		mTransform.condition();
+
+		translation2 *= mBindTransform;
+		mBindTransform = translation2;
+		mBindTransform.condition();
 	}
 
 	domRotate* rotate = daeSafeCast<domRotate>(element);
@@ -2048,12 +2032,17 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 	{
 		domFloat4 dom_value = rotate->getValue();
 
-		LLMatrix4 rotation;
+		LLMatrix4 rotation, rotation2;
 		rotation.initRotTrans(dom_value[3] * DEG_TO_RAD, LLVector3(dom_value[0], dom_value[1], dom_value[2]), LLVector3(0, 0, 0));
+		rotation2 = rotation;
 
 		rotation *= mTransform;
 		mTransform = rotation;
 		mTransform.condition();
+
+		rotation2 *= mBindTransform;
+		mBindTransform = rotation2;
+		mBindTransform.condition();
 	}
 
 	domScale* scale = daeSafeCast<domScale>(element);
@@ -2064,12 +2053,17 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 
 		LLVector3 scale_vector = LLVector3(dom_value[0], dom_value[1], dom_value[2]);
 		scale_vector.abs(); // Set all values positive, since we don't currently support mirrored meshes
-		LLMatrix4 scaling;
+		LLMatrix4 scaling, scaling2;
 		scaling.initScale(scale_vector);
+		scaling2 = scaling;
 
 		scaling *= mTransform;
 		mTransform = scaling;
 		mTransform.condition();
+
+		scaling2 *= mBindTransform;
+		mBindTransform = scaling2;
+		mBindTransform.condition();
 	}
 
 	domMatrix* matrix = daeSafeCast<domMatrix>(element);
@@ -2077,7 +2071,7 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 	{
 		domFloat4x4 dom_value = matrix->getValue();
 
-		LLMatrix4 matrix_transform;
+		LLMatrix4 matrix_transform, matrix_transform2;
 
 		for (int i = 0; i < 4; i++)
 		{
@@ -2087,9 +2081,15 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 			}
 		}
 
+		matrix_transform2 = matrix_transform;
+
 		matrix_transform *= mTransform;
 		mTransform = matrix_transform;
 		mTransform.condition();
+
+		matrix_transform2 *= mBindTransform;
+		mBindTransform = matrix_transform2;
+		mBindTransform.condition();
 	}
 
 	domInstance_geometry* instance_geo = daeSafeCast<domInstance_geometry>(element);
@@ -2186,7 +2186,36 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 		daeElement* instance = instance_node->getUrl().getElement();
 		if (instance)
 		{
-			processElement(instance,badElement, dae);
+			processElement(instance,badElement, dae, domRoot);
+		}
+	}
+
+	domInstance_controller* instance_ctl = daeSafeCast<domInstance_controller>(element);
+	if (instance_ctl)
+	{
+		domController* ctl = daeSafeCast<domController>(instance_ctl->getUrl().getElement());
+		if (ctl)
+		{
+			domSkin* skin = ctl->getSkin();
+			if (skin)
+			{
+				domGeometry* geom = daeSafeCast<domGeometry>(skin->getSource().getElement());
+
+				if (geom)
+				{
+					domMesh* mesh = geom->getMesh();
+					if (mesh)
+					{
+						std::vector< LLPointer< LLModel > >::iterator i = mModelsMap[mesh].begin();
+						while (i != mModelsMap[mesh].end())
+						{
+							LLPointer<LLModel> mdl = *i;
+							LLDAELoader::processDomModel(mdl, dae, domRoot, mesh, skin);
+							i++;
+						}
+					}
+				}
+			}
 		}
 	}
 
@@ -2195,12 +2224,13 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 	int childCount = children.getCount();
 	for (S32 i = 0; i < childCount; i++)
 	{
-		processElement(children[i],badElement, dae);
+		processElement(children[i],badElement, dae, domRoot);
 	}
 
 	if (pushed_mat)
 	{ //this element was a node, restore transform before processiing siblings
 		mTransform = saved_transform;
+		mBindTransform = saved_bind_transform;
 	}
 }
 

--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -1266,6 +1266,8 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
 			skin_info.mBindShapeMatrix = trans;							
 		}
 
+		// Build the joint to node mapping array and update joint aliases (mJointMap)
+		buildJointToNodeMappingFromScene(root);
 
 		//Some collada setup for accessing the skeleton
 		U32 skeleton_count = dae->getDatabase()->getElementCount( NULL, "skeleton" );
@@ -1491,8 +1493,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
 		//Now that we've parsed the joint array, let's determine if we have a full rig
 		//(which means we have all the joint sthat are required for an avatar versus
 		//a skinned asset attached to a node in a file that contains an entire skeleton,
-		//but does not use the skeleton).						
-		buildJointToNodeMappingFromScene( root );
+		//but does not use the skeleton).
 		critiqueRigForUploadApplicability( model->mSkinInfo.mJointNames );
 
 		if ( !missingSkeletonOrScene )
@@ -1729,6 +1730,8 @@ void LLDAELoader::processJointToNodeMapping( domNode* pNode )
 		if (!nodeName.empty())
 		{
 			mJointsFromNode.push_front(pNode->getName());
+			// Alias joint node SIDs to joint names for compatibility
+			mJointMap[pNode->getSid()] = mJointMap[pNode->getName()];
 		}
 		//2. Handle the kiddo's
 		processChildJoints(pNode);

--- a/indra/llprimitive/lldaeloader.h
+++ b/indra/llprimitive/lldaeloader.h
@@ -66,7 +66,7 @@ public:
 
 protected:
 
-	void processElement(daeElement* element, bool& badElement, DAE* dae);
+	void processElement(daeElement* element, bool& badElement, DAE* dae, daeElement* domRoot);
 	void processDomModel(LLModel* model, DAE* dae, daeElement* pRoot, domMesh* mesh, domSkin* skin);
 
 	material_map getMaterials(LLModel* model, domInstance_geometry* instance_geo, DAE* dae);

--- a/indra/llprimitive/llmodelloader.h
+++ b/indra/llprimitive/llmodelloader.h
@@ -99,7 +99,7 @@ public:
 	
 	S32 mLod;
 	
-	LLMatrix4 mTransform;
+	LLMatrix4 mTransform, mBindTransform;
 	BOOL mFirstTransform;
 	LLVector3 mExtents[2];
 	


### PR DESCRIPTION
### Summary
These changes make skinned meshes imported by instance_controller elements rather than directly by the skin element in each library_controller. This allows for the mesh and its bind pose matrices to be transformed by the TRS (translation, rotation, scale) or matrix of the instance_controller in the scene hierarchy for the correct pose when imported by LLDAELoader.

### How and Why
Using instance_controller elements instead of enumerating library_controller>skin elements allows the loader to use the transform information from instance_controller and correctly orient the model, therefore removing the precondition requirement of identity TRS/matrix of skinned meshes. This normalizes the import process because different 3D modeling programs have different ways of handling up and/or forward axes export options. This enables an easier workflow for content creators and improved compatibility with modeling softwares.

### Testing for Issues
These changes have not been rigorously tested for bugs, side effects, or edge cases. From these changes, is plausible that multiple instance_controller elements with the same src attribute could result in redundant mesh data and could affect mesh optimization. Some 3D modeling programs create redundant library_controller elements for instances of a mesh object when exporting to DAE format, even when it is instanced in the original scene by that program's native format. In my own testing, none of these potential issues were found.